### PR TITLE
Remove proxyquire module

### DIFF
--- a/test/closure-linter-wrapper_test.js
+++ b/test/closure-linter-wrapper_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var proxyquire = require('proxyquire'),
-    closure_linter = require('../lib/closure-linter-wrapper'),
+var closure_linter = require('../lib/closure-linter-wrapper'),
     fs = require('fs');
 
 


### PR DESCRIPTION
I see that this module is not being used for now and when running "npm test" it fails on finding it.
