### PR TITLE
Fix parse-result problem with Windows OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Icon
 
 # Sublime Text
 *.sublime-*
+
+# Eclipse
+.project

--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -16,7 +16,7 @@ var exec = require('child_process').exec,
     abstractRegex = new RegExp('^Found ([\\d]+) errors, including ([\\d]+) ' +
         'new errors, in ([\\d]+) files \\(([\\d]+) files OK\\).?$'),
     successRegex = new RegExp('^([\\d]+) file.*no errors found.?$'),
-    skippingRegex = new RegExp('^Skipping \\d file\\(s\\)\\.?$');
+    skippingRegex = new RegExp('^Skipping ([\\d]+) file\\(s\\)\\.?$');
 
 
 function createError(code, description, info) {
@@ -149,16 +149,22 @@ function execute(program, options, callback) {
     fullCommand = params.join(' ');
 
     exec(fullCommand, function(err, stdout, stderr) {
+      var result = '';
+
       if (err && stderr !== '') {
         callback(createErrorExecutingClosureLinter(fullCommand, stderr));
         return;
       }
 
+      if (stdout && typeof stdout === 'string') {
+        result = stdout.replace(/\r/g, '');
+      }
+
       //TODO: Move this management before execute call
       if (program === 'gjslint') {
-        parseResult(stdout, callback);
+        parseResult(result, callback);
       } else {
-        callback(err, stdout);
+        callback(err, result);
       }
 
     });


### PR DESCRIPTION
Modifications:
- Add Eclipse _.project_ file to the ignore files.
- Replace the Windows `\r` characters.
- Fix the skipping regular-expression.
