### PR TITLE
Add support for Arch Linux

### DIFF
--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -10,7 +10,7 @@
 
 var exec = require('child_process').exec,
     path = require('path'),
-    checkPythonCommand = 'python --version',
+    checkPythonCommand = 'python2 --version',
     fileRegex = new RegExp('^\\x2D{5}\\s+FILE\\s+:\\s+([^\\s]+)\\s+\\x2D{5}$'),
     errorRegex = new RegExp('^Line\\s(\\d+),\\sE:([\\d]+):\\s(.*)$'),
     abstractRegex = new RegExp('^Found ([\\d]+) errors, including ([\\d]+) ' +
@@ -140,7 +140,7 @@ function execute(program, options, callback) {
     var flags = options.flags || [],
         src = options.src || [],
         params = [],
-        cmd = path.normalize('python ' + __dirname +
+        cmd = path.normalize('python2 ' + __dirname +
             '/../tools/' + program + '.py'),
         fullCommand;
 


### PR DESCRIPTION
Arch Linux's default python version is python3, with which the closure linter isn't compatible.
Specifying `python2` explicitly ensures that the correct version of python is called.

On other Linux distributions (eg. Ubuntu, Debian, Mint) the python2 command works as expected.