### PR TITLE
Fix for using the module in a path with spaces

### DIFF
--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -140,8 +140,8 @@ function execute(program, options, callback) {
     var flags = options.flags || [],
         src = options.src || [],
         params = [],
-        cmd = path.normalize('python ' + __dirname +
-            '/../tools/' + program + '.py'),
+        cmd = path.normalize('python "' + __dirname +
+            '/../tools/' + program + '.py"'),
         fullCommand;
 
     params.push(cmd);

--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -140,8 +140,8 @@ function execute(program, options, callback) {
     var flags = options.flags || [],
         src = options.src || [],
         params = [],
-        cmd = path.normalize('python "' + __dirname +
-            '/../tools/' + program + '.py"'),
+        cmd = path.normalize('python \'' + __dirname +
+            '/../tools/' + program + '.py\''),
         fullCommand;
 
     params.push(cmd);


### PR DESCRIPTION
When using the module installed on a base path containing spaces (im my case, the system path is */Volumes/Macintosh SSD* and the workspace path is */Volumes/Macintosh HD/Users/dcm/project*), the command fails.

```
Cannot execute gjslint!
python /Volumes/Macintosh HD/Users/dcm/project/node_modules/closure-linter-wrapper/tools/gjslint.py --flagfile .gjslintrc app.js 
python: can't open file '/Volumes/Macintosh': [Errno 2] No such file or directory
```

This PR tries to fix this.