### PR TITLE
Support negative error numbers

### DIFF
--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -11,7 +11,7 @@
 var exec = require('child_process').exec,
     path = require('path'),
     fileRegex = new RegExp('^\\x2D{5}\\s+FILE\\s+:\\s+([^\\s]+)\\s+\\x2D{5}$'),
-    errorRegex = new RegExp('^Line\\s(\\d+),\\sE:([\\d]+):\\s(.*)$'),
+    errorRegex = new RegExp('^Line\\s(\\d+),\\sE:(-?[\\d]+):\\s(.*)$'),
     abstractRegex = new RegExp('^Found ([\\d]+) errors?, including ([\\d]+) ' +
         'new errors?, in ([\\d]+) files? \\(([\\d]+) files? OK\\).?$'),
     successRegex = new RegExp('^([\\d]+) file.*no errors found.?$'),

--- a/test/closure-linter-wrapper_test.js
+++ b/test/closure-linter-wrapper_test.js
@@ -57,9 +57,11 @@ describe('Closure Linter Wrapper', function() {
 
         var data = err.info;
         expect(data).to.have.property('filesCount').to.be.equal(2);
-        expect(data).to.have.property('total').to.be.equal(3);
+        expect(data).to.have.property('total').to.be.equal(4);
         expect(data).to.have.property('newErrors').to.be.equal(0);
-        expect(data).to.have.property('filesOK').to.be.equal(0);
+        expect(data).to.have.property('fails').to.have.length(2);
+        expect(data.fails[0]).to.have.property('errors').to.have.length(3);
+        expect(data.fails[1]).to.have.property('errors').to.have.length(1);
         done();
       });
     });
@@ -92,7 +94,7 @@ describe('Closure Linter Wrapper', function() {
         expect(fails).to.have.length(2);
 
         expect(fails[0]).to.have.property('file').to.be.equal('/Users/foo.js');
-        expect(fails[0]).to.have.property('errors').to.have.length(2);
+        expect(fails[0]).to.have.property('errors').to.have.length(3);
 
         var errors = fails[0].errors;
         expect(errors[0]).to.have.property('line').to.be.equal(3);

--- a/test/files/error.txt
+++ b/test/files/error.txt
@@ -1,9 +1,10 @@
 ----- FILE  :  /Users/foo.js -----
 Line 3, E:0220: No docs found for member 'module.exports'
 Line 5, E:0020: Something
+Line 93, E:-002: Error parsing file at token "<JavaScriptToken: 93, }, "}", {}, MetaData(None)>". Unable to check the rest of file.
 ----- FILE  :  /Users/bar.js -----
 Line 4, E:0220: No docs found for member 'global.expect'
-Found 3 errors, including 0 new errors, in 2 file (0 files OK).
+Found 4 errors, including 0 new errors, in 2 file (0 files OK).
 
 Some of the errors reported by GJsLint may be auto-fixable using the script
 fixjsstyle. Please double check any changes it makes and report any bugs. The


### PR DESCRIPTION
I ran into an error of the form

```
Line 93, E:-002: Error parsing file at token "<JavaScriptToken: 93, }, "}", {}, MetaData(None)>". Unable to check the rest of file.
```

which wasn't captured by the wrapper, so it wasn't visible until I ran gjslint directly. This seems to fix it.
