### PR TITLE
Fix for showing detailed "failing" report of files with spaces in path

### DIFF
--- a/lib/closure-linter-wrapper.js
+++ b/lib/closure-linter-wrapper.js
@@ -10,7 +10,7 @@
 
 var exec = require('child_process').exec,
     path = require('path'),
-    fileRegex = new RegExp('^\\x2D{5}\\s+FILE\\s+:\\s+([^\\s]+)\\s+\\x2D{5}$'),
+    fileRegex = new RegExp('^\\x2D{5}\\s+FILE\\s+:\\s+(.+)\\s+\\x2D{5}$'),
     errorRegex = new RegExp('^Line\\s(\\d+),\\sE:([\\d]+):\\s(.*)$'),
     abstractRegex = new RegExp('^Found ([\\d]+) errors?, including ([\\d]+) ' +
         'new errors?, in ([\\d]+) files? \\(([\\d]+) files? OK\\).?$'),

--- a/test/closure-linter-wrapper_test.js
+++ b/test/closure-linter-wrapper_test.js
@@ -119,6 +119,46 @@ describe('Closure Linter Wrapper', function() {
         done();
       });
     });
+
+    it('should be able to parse details of wrong run with spaces in file path', function(done) {
+      var successText = fs.readFileSync('test/files/error-path-with-spaces.txt', 'utf8');
+
+      closure_linter.parseResult(successText, function(err, result){
+        expect(result).to.be.undefined;
+        expect(err).to.have.property('code').to.be.equal(2);
+        expect(err).to.have.property('info').to.have.property('fails');
+
+        var fails = err.info.fails;
+        expect(fails).to.have.length(2);
+
+        expect(fails[0]).to.have.property('file').to.be.equal('/Users/my path/foo.js');
+        expect(fails[0]).to.have.property('errors').to.have.length(2);
+
+        var errors = fails[0].errors;
+        expect(errors[0]).to.have.property('line').to.be.equal(3);
+        expect(errors[0]).to.have.property('code').to.be.equal(220);
+        expect(errors[0]).to.have.property('description').to.be.equal(
+            'No docs found for member \'module.exports\''
+        );
+
+        expect(errors[1]).to.have.property('line').to.be.equal(5);
+        expect(errors[1]).to.have.property('code').to.be.equal(20);
+        expect(errors[1]).to.have.property('description').to.be.equal(
+            'Something'
+        );
+
+        expect(fails[1]).to.have.property('file').to.be.equal('/Users/my path/bar.js');
+        expect(fails[1]).to.have.property('errors').to.have.length(1);
+
+        errors = fails[1].errors;
+        expect(errors[0]).to.have.property('line').to.be.equal(4);
+        expect(errors[0]).to.have.property('code').to.be.equal(220);
+        expect(errors[0]).to.have.property('description').to.be.equal(
+            'No docs found for member \'global.expect\''
+        );
+        done();
+      });
+    });
   });
 
   describe('gjslint', function () {

--- a/test/files/error-path-with-spaces.txt
+++ b/test/files/error-path-with-spaces.txt
@@ -1,0 +1,12 @@
+----- FILE  :  /Users/my path/foo.js -----
+Line 3, E:0220: No docs found for member 'module.exports'
+Line 5, E:0020: Something
+----- FILE  :  /Users/my path/bar.js -----
+Line 4, E:0220: No docs found for member 'global.expect'
+Found 3 errors, including 0 new errors, in 2 file (0 files OK).
+
+Some of the errors reported by GJsLint may be auto-fixable using the script
+fixjsstyle. Please double check any changes it makes and report any bugs. The
+script can be run by executing:
+
+fixjsstyle Gruntfile.js mocha-globals.js


### PR DESCRIPTION
Right now, the current implementation doesn't show the fail details when the affected source file has a space in its path.

Currently, this is the report that is shown for a JS file that fails in the gjslint validation:

```
Running "gjslint:lib" (gjslint) task
gjslint linting failed!

Found 1 errors, including 0 new errors, in 1  files (4 files OK).
```

This PR fixes it. The final report with this fix will be like:

```
Running "gjslint:lib" (gjslint) task
gjslint linting failed!
/Volumes/Macintosh HD/Users/dcantelar/project/file.js
  [#7] Missing type in @param tag (Error 213)

Found 1 errors, including 0 new errors, in 1  files (4 files OK).
```
